### PR TITLE
Postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "scripts": {
         "build": "tsc",
         "watch": "tsc -w",
-        "postinstall": "npm run build"
+        "install": "npm run build"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "scripts": {
         "build": "tsc",
         "watch": "tsc -w",
-        "install": "npm run build"
+        "postinstall": "npm run build"
     },
     "repository": {
         "type": "git",
@@ -26,6 +26,7 @@
         "@aws-cdk/aws-s3": "^1.62.0",
         "@aws-cdk/core": "^1.62.0",
         "@types/bluebird": "^3.5.32",
+        "@types/node": "^12.12.47",
         "@types/uuid": "^3.4.9",
         "aws-cdk": "^1.62.0",
         "aws-sdk": "^2.745.0",
@@ -36,7 +37,6 @@
         "uuid": "^3.4.0"
     },
     "devDependencies": {
-        "@types/node": "^12.12.47",
         "serverless": "^1.73.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     },
     "scripts": {
         "build": "tsc",
-        "watch": "tsc -w"
+        "watch": "tsc -w",
+        "postinstall": "npm run build"
     },
     "repository": {
         "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target":"ES2018",
+    "target": "ES2018",
     "module": "commonjs",
-    "lib": ["es2016", "es2017.object", "es2017.string"],
+    "lib": ["es2016", "es2017.object", "es2017.string", "dom"],
     "declaration": true,
     "strict": true,
     "noImplicitAny": true,
@@ -16,7 +16,7 @@
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,
-    "strictPropertyInitialization":false
+    "strictPropertyInitialization": false
   },
   "exclude": ["cdk.out"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     "experimentalDecorators": true,
     "strictPropertyInitialization": false
   },
-  "exclude": ["cdk.out"]
+  "exclude": ["cdk.out/**/*", "node_modules/**/*"]
 }


### PR DESCRIPTION
Based on https://github.com/snap40/serverless-aws-cdk/pull/4

Trying to make it possible to install this package from git, because I want to use the fixed version in that PR.

Unfortunately I'm stuck trying to build it with `tsc`:
```
cdk/toolkitStack.ts:5:32 - error TS2307: Cannot find module './environment' or its corresponding type declarations.

5 import { getEnvironment } from './environment'
```
I'm not really sure how I can install and test this module with that missing file