### PR TITLE
[Fix] getEnvironment lives inside provider

### DIFF
--- a/cdk/toolkitStack.ts
+++ b/cdk/toolkitStack.ts
@@ -2,7 +2,6 @@ import Serverless = require('serverless');
 
 import { Bootstrapper, ToolkitInfo } from 'aws-cdk';
 import { AwsCdkDeploy } from '../deploy'
-import { getEnvironment } from './environment'
 
 function getToolkitStackName(serverless: Serverless) {
   // DEFAULT_TOOLKIT_STACK_NAME from aws-cdk/deployment-target
@@ -11,7 +10,7 @@ function getToolkitStackName(serverless: Serverless) {
 }
 
 export async function bootstrapToolkitStack(this: AwsCdkDeploy) {
-  const environment = await getEnvironment(this.provider);
+  const environment = await this.provider.getEnvironment();
   const toolkitStackName = getToolkitStackName(this.serverless);
   const roleArn = this.provider.getCfnRoleArn();
   const bootstrapper = new Bootstrapper({ source: 'default' });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "serverless-aws-cdk",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1591,6 +1591,739 @@
                         "aws-sdk": "^2.739.0",
                         "glob": "^7.1.6",
                         "yargs": "^15.4.1"
+                    },
+                    "dependencies": {
+                        "@aws-cdk/cloud-assembly-schema": {
+                            "version": "1.62.0",
+                            "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.62.0.tgz",
+                            "integrity": "sha512-bEXUKIlRxn7be7R4kJ/4G/orI6YNuDeXZ9znIKiUT/xxeiT0Pg96XNsQW6dHTusgkullCTuiYP/EDiaic+8T0A==",
+                            "requires": {
+                                "jsonschema": "^1.2.5",
+                                "semver": "^7.2.2"
+                            }
+                        },
+                        "@aws-cdk/cx-api": {
+                            "version": "1.62.0",
+                            "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.62.0.tgz",
+                            "integrity": "sha512-qyT/TnbO14z14mDly1jgeuFtVRYHwId5ZDJIsGOCsJJNXU9QpaElB9uD+qS1vB6Y/VI6KJTogBh45KW337BaEg==",
+                            "requires": {
+                                "@aws-cdk/cloud-assembly-schema": "1.62.0",
+                                "semver": "^7.2.2"
+                            }
+                        },
+                        "@types/color-name": {
+                            "version": "1.1.1",
+                            "resolved": "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0",
+                            "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+                        },
+                        "ansi-regex": {
+                            "version": "5.0.0",
+                            "resolved": "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75",
+                            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+                        },
+                        "ansi-styles": {
+                            "version": "4.2.1",
+                            "resolved": "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359",
+                            "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                            "requires": {
+                                "@types/color-name": "^1.1.1",
+                                "color-convert": "^2.0.1"
+                            }
+                        },
+                        "archiver": {
+                            "version": "4.0.2",
+                            "resolved": "https://registry.yarnpkg.com/archiver/-/archiver-4.0.2.tgz#43c72865eadb4ddaaa2fb74852527b6a450d927c",
+                            "integrity": "sha512-B9IZjlGwaxF33UN4oPbfBkyA4V1SxNLeIhR1qY8sRXSsbdUkEHrrOvwlYFPx+8uQeCe9M+FG6KgO+imDmQ79CQ==",
+                            "requires": {
+                                "archiver-utils": "^2.1.0",
+                                "async": "^3.2.0",
+                                "buffer-crc32": "^0.2.1",
+                                "glob": "^7.1.6",
+                                "readable-stream": "^3.6.0",
+                                "tar-stream": "^2.1.2",
+                                "zip-stream": "^3.0.1"
+                            },
+                            "dependencies": {
+                                "readable-stream": {
+                                    "version": "3.6.0",
+                                    "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198",
+                                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                                    "requires": {
+                                        "inherits": "^2.0.3",
+                                        "string_decoder": "^1.1.1",
+                                        "util-deprecate": "^1.0.1"
+                                    }
+                                },
+                                "safe-buffer": {
+                                    "version": "5.2.1",
+                                    "resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6",
+                                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+                                },
+                                "string_decoder": {
+                                    "version": "1.3.0",
+                                    "resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e",
+                                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+                                    "requires": {
+                                        "safe-buffer": "~5.2.0"
+                                    }
+                                }
+                            }
+                        },
+                        "archiver-utils": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.yarnpkg.com/archiver-utils/-/archiver-utils-2.1.0.tgz#e8a460e94b693c3e3da182a098ca6285ba9249e2",
+                            "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+                            "requires": {
+                                "glob": "^7.1.4",
+                                "graceful-fs": "^4.2.0",
+                                "lazystream": "^1.0.0",
+                                "lodash.defaults": "^4.2.0",
+                                "lodash.difference": "^4.5.0",
+                                "lodash.flatten": "^4.4.0",
+                                "lodash.isplainobject": "^4.0.6",
+                                "lodash.union": "^4.6.0",
+                                "normalize-path": "^3.0.0",
+                                "readable-stream": "^2.0.0"
+                            }
+                        },
+                        "async": {
+                            "version": "3.2.0",
+                            "resolved": "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720",
+                            "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+                        },
+                        "aws-sdk": {
+                            "version": "2.739.0",
+                            "resolved": "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.739.0.tgz#10b0b29be18c3f0f85ca145cbed8b10793ddc7a7",
+                            "integrity": "sha512-N2XyxY12gs0GJc26O8TmdT30ovEKWsPX787CNW24g0cXTCyc/Teltq0re6yGxfaH0VmN6qONNLr3E59JtJ3neA==",
+                            "requires": {
+                                "buffer": "4.9.2",
+                                "events": "1.1.1",
+                                "ieee754": "1.1.13",
+                                "jmespath": "0.15.0",
+                                "querystring": "0.2.0",
+                                "sax": "1.2.1",
+                                "url": "0.10.3",
+                                "uuid": "3.3.2",
+                                "xml2js": "0.4.19"
+                            },
+                            "dependencies": {
+                                "buffer": {
+                                    "version": "4.9.2",
+                                    "resolved": "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8",
+                                    "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+                                    "requires": {
+                                        "base64-js": "^1.0.2",
+                                        "ieee754": "^1.1.4",
+                                        "isarray": "^1.0.0"
+                                    }
+                                }
+                            }
+                        },
+                        "balanced-match": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767",
+                            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+                        },
+                        "base64-js": {
+                            "version": "1.3.1",
+                            "resolved": "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1",
+                            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+                        },
+                        "bl": {
+                            "version": "4.0.3",
+                            "resolved": "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489",
+                            "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+                            "requires": {
+                                "buffer": "^5.5.0",
+                                "inherits": "^2.0.4",
+                                "readable-stream": "^3.4.0"
+                            },
+                            "dependencies": {
+                                "readable-stream": {
+                                    "version": "3.6.0",
+                                    "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198",
+                                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                                    "requires": {
+                                        "inherits": "^2.0.3",
+                                        "string_decoder": "^1.1.1",
+                                        "util-deprecate": "^1.0.1"
+                                    }
+                                },
+                                "safe-buffer": {
+                                    "version": "5.2.1",
+                                    "resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6",
+                                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+                                },
+                                "string_decoder": {
+                                    "version": "1.3.0",
+                                    "resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e",
+                                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+                                    "requires": {
+                                        "safe-buffer": "~5.2.0"
+                                    }
+                                }
+                            }
+                        },
+                        "brace-expansion": {
+                            "version": "1.1.11",
+                            "resolved": "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
+                            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+                            "requires": {
+                                "balanced-match": "^1.0.0",
+                                "concat-map": "0.0.1"
+                            }
+                        },
+                        "buffer": {
+                            "version": "5.6.0",
+                            "resolved": "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786",
+                            "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+                            "requires": {
+                                "base64-js": "^1.0.2",
+                                "ieee754": "^1.1.4"
+                            }
+                        },
+                        "buffer-crc32": {
+                            "version": "0.2.13",
+                            "resolved": "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242",
+                            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+                        },
+                        "camelcase": {
+                            "version": "5.3.1",
+                            "resolved": "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320",
+                            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+                        },
+                        "cliui": {
+                            "version": "6.0.0",
+                            "resolved": "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1",
+                            "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+                            "requires": {
+                                "string-width": "^4.2.0",
+                                "strip-ansi": "^6.0.0",
+                                "wrap-ansi": "^6.2.0"
+                            }
+                        },
+                        "color-convert": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3",
+                            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                            "requires": {
+                                "color-name": "~1.1.4"
+                            }
+                        },
+                        "color-name": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2",
+                            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+                        },
+                        "compress-commons": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.yarnpkg.com/compress-commons/-/compress-commons-3.0.0.tgz#833944d84596e537224dd91cf92f5246823d4f1d",
+                            "integrity": "sha512-FyDqr8TKX5/X0qo+aVfaZ+PVmNJHJeckFBlq8jZGSJOgnynhfifoyl24qaqdUdDIBe0EVTHByN6NAkqYvE/2Xg==",
+                            "requires": {
+                                "buffer-crc32": "^0.2.13",
+                                "crc32-stream": "^3.0.1",
+                                "normalize-path": "^3.0.0",
+                                "readable-stream": "^2.3.7"
+                            }
+                        },
+                        "concat-map": {
+                            "version": "0.0.1",
+                            "resolved": "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b",
+                            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                        },
+                        "core-util-is": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7",
+                            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                        },
+                        "crc": {
+                            "version": "3.8.0",
+                            "resolved": "https://registry.yarnpkg.com/crc/-/crc-3.8.0.tgz#ad60269c2c856f8c299e2c4cc0de4556914056c6",
+                            "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+                            "requires": {
+                                "buffer": "^5.1.0"
+                            }
+                        },
+                        "crc32-stream": {
+                            "version": "3.0.1",
+                            "resolved": "https://registry.yarnpkg.com/crc32-stream/-/crc32-stream-3.0.1.tgz#cae6eeed003b0e44d739d279de5ae63b171b4e85",
+                            "integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
+                            "requires": {
+                                "crc": "^3.4.4",
+                                "readable-stream": "^3.4.0"
+                            },
+                            "dependencies": {
+                                "readable-stream": {
+                                    "version": "3.6.0",
+                                    "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198",
+                                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                                    "requires": {
+                                        "inherits": "^2.0.3",
+                                        "string_decoder": "^1.1.1",
+                                        "util-deprecate": "^1.0.1"
+                                    }
+                                },
+                                "safe-buffer": {
+                                    "version": "5.2.1",
+                                    "resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6",
+                                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+                                },
+                                "string_decoder": {
+                                    "version": "1.3.0",
+                                    "resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e",
+                                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+                                    "requires": {
+                                        "safe-buffer": "~5.2.0"
+                                    }
+                                }
+                            }
+                        },
+                        "decamelize": {
+                            "version": "1.2.0",
+                            "resolved": "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290",
+                            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+                        },
+                        "emoji-regex": {
+                            "version": "8.0.0",
+                            "resolved": "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37",
+                            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+                        },
+                        "end-of-stream": {
+                            "version": "1.4.4",
+                            "resolved": "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0",
+                            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+                            "requires": {
+                                "once": "^1.4.0"
+                            }
+                        },
+                        "events": {
+                            "version": "1.1.1",
+                            "resolved": "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924",
+                            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+                        },
+                        "find-up": {
+                            "version": "4.1.0",
+                            "resolved": "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19",
+                            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                            "requires": {
+                                "locate-path": "^5.0.0",
+                                "path-exists": "^4.0.0"
+                            }
+                        },
+                        "fs-constants": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad",
+                            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+                        },
+                        "fs.realpath": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f",
+                            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+                        },
+                        "get-caller-file": {
+                            "version": "2.0.5",
+                            "resolved": "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e",
+                            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+                        },
+                        "glob": {
+                            "version": "7.1.6",
+                            "resolved": "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6",
+                            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+                            "requires": {
+                                "fs.realpath": "^1.0.0",
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "^3.0.4",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
+                            }
+                        },
+                        "graceful-fs": {
+                            "version": "4.2.4",
+                            "resolved": "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb",
+                            "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+                        },
+                        "ieee754": {
+                            "version": "1.1.13",
+                            "resolved": "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84",
+                            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+                        },
+                        "inflight": {
+                            "version": "1.0.6",
+                            "resolved": "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9",
+                            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                            "requires": {
+                                "once": "^1.3.0",
+                                "wrappy": "1"
+                            }
+                        },
+                        "inherits": {
+                            "version": "2.0.4",
+                            "resolved": "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c",
+                            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d",
+                            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+                        },
+                        "isarray": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11",
+                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                        },
+                        "jmespath": {
+                            "version": "0.15.0",
+                            "resolved": "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217",
+                            "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+                        },
+                        "jsonschema": {
+                            "version": "1.2.6",
+                            "resolved": "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.2.6.tgz#52b0a8e9dc06bbae7295249d03e4b9faee8a0c0b",
+                            "integrity": "sha512-SqhURKZG07JyKKeo/ir24QnS4/BV7a6gQy93bUSe4lUdNp0QNpIz2c9elWJQ9dpc5cQYY6cvCzgRwy0MQCLyqA=="
+                        },
+                        "lazystream": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4",
+                            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+                            "requires": {
+                                "readable-stream": "^2.0.5"
+                            }
+                        },
+                        "locate-path": {
+                            "version": "5.0.0",
+                            "resolved": "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0",
+                            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+                            "requires": {
+                                "p-locate": "^4.1.0"
+                            }
+                        },
+                        "lodash.defaults": {
+                            "version": "4.2.0",
+                            "resolved": "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c",
+                            "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+                        },
+                        "lodash.difference": {
+                            "version": "4.5.0",
+                            "resolved": "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c",
+                            "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+                        },
+                        "lodash.flatten": {
+                            "version": "4.4.0",
+                            "resolved": "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f",
+                            "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+                        },
+                        "lodash.isplainobject": {
+                            "version": "4.0.6",
+                            "resolved": "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb",
+                            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+                        },
+                        "lodash.union": {
+                            "version": "4.6.0",
+                            "resolved": "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88",
+                            "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
+                        },
+                        "minimatch": {
+                            "version": "3.0.4",
+                            "resolved": "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083",
+                            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                            "requires": {
+                                "brace-expansion": "^1.1.7"
+                            }
+                        },
+                        "normalize-path": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65",
+                            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+                        },
+                        "once": {
+                            "version": "1.4.0",
+                            "resolved": "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1",
+                            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                            "requires": {
+                                "wrappy": "1"
+                            }
+                        },
+                        "p-limit": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1",
+                            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                            "requires": {
+                                "p-try": "^2.0.0"
+                            }
+                        },
+                        "p-locate": {
+                            "version": "4.1.0",
+                            "resolved": "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07",
+                            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+                            "requires": {
+                                "p-limit": "^2.2.0"
+                            }
+                        },
+                        "p-try": {
+                            "version": "2.2.0",
+                            "resolved": "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6",
+                            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+                        },
+                        "path-exists": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3",
+                            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+                        },
+                        "path-is-absolute": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
+                            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+                        },
+                        "process-nextick-args": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2",
+                            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+                        },
+                        "punycode": {
+                            "version": "1.3.2",
+                            "resolved": "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d",
+                            "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+                        },
+                        "querystring": {
+                            "version": "0.2.0",
+                            "resolved": "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620",
+                            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+                        },
+                        "readable-stream": {
+                            "version": "2.3.7",
+                            "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57",
+                            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "require-directory": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
+                            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+                        },
+                        "require-main-filename": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b",
+                            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+                        },
+                        "safe-buffer": {
+                            "version": "5.1.2",
+                            "resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d",
+                            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                        },
+                        "sax": {
+                            "version": "1.2.1",
+                            "resolved": "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a",
+                            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+                        },
+                        "semver": {
+                            "version": "7.3.2",
+                            "resolved": "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938",
+                            "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+                        },
+                        "set-blocking": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7",
+                            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+                        },
+                        "string-width": {
+                            "version": "4.2.0",
+                            "resolved": "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5",
+                            "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+                            "requires": {
+                                "emoji-regex": "^8.0.0",
+                                "is-fullwidth-code-point": "^3.0.0",
+                                "strip-ansi": "^6.0.0"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8",
+                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "6.0.0",
+                            "resolved": "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532",
+                            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                            "requires": {
+                                "ansi-regex": "^5.0.0"
+                            }
+                        },
+                        "tar-stream": {
+                            "version": "2.1.3",
+                            "resolved": "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.1.3.tgz#1e2022559221b7866161660f118255e20fa79e41",
+                            "integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
+                            "requires": {
+                                "bl": "^4.0.1",
+                                "end-of-stream": "^1.4.1",
+                                "fs-constants": "^1.0.0",
+                                "inherits": "^2.0.3",
+                                "readable-stream": "^3.1.1"
+                            },
+                            "dependencies": {
+                                "readable-stream": {
+                                    "version": "3.6.0",
+                                    "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198",
+                                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                                    "requires": {
+                                        "inherits": "^2.0.3",
+                                        "string_decoder": "^1.1.1",
+                                        "util-deprecate": "^1.0.1"
+                                    }
+                                },
+                                "safe-buffer": {
+                                    "version": "5.2.1",
+                                    "resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6",
+                                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+                                },
+                                "string_decoder": {
+                                    "version": "1.3.0",
+                                    "resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e",
+                                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+                                    "requires": {
+                                        "safe-buffer": "~5.2.0"
+                                    }
+                                }
+                            }
+                        },
+                        "url": {
+                            "version": "0.10.3",
+                            "resolved": "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64",
+                            "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+                            "requires": {
+                                "punycode": "1.3.2",
+                                "querystring": "0.2.0"
+                            }
+                        },
+                        "util-deprecate": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf",
+                            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+                        },
+                        "uuid": {
+                            "version": "3.3.2",
+                            "resolved": "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131",
+                            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+                        },
+                        "which-module": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a",
+                            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+                        },
+                        "wrap-ansi": {
+                            "version": "6.2.0",
+                            "resolved": "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53",
+                            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+                            "requires": {
+                                "ansi-styles": "^4.0.0",
+                                "string-width": "^4.1.0",
+                                "strip-ansi": "^6.0.0"
+                            }
+                        },
+                        "wrappy": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
+                            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+                        },
+                        "xml2js": {
+                            "version": "0.4.19",
+                            "resolved": "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7",
+                            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+                            "requires": {
+                                "sax": ">=0.6.0",
+                                "xmlbuilder": "~9.0.1"
+                            },
+                            "dependencies": {
+                                "sax": {
+                                    "version": "1.2.4",
+                                    "resolved": "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9",
+                                    "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+                                }
+                            }
+                        },
+                        "xmlbuilder": {
+                            "version": "9.0.7",
+                            "resolved": "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d",
+                            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+                        },
+                        "y18n": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b",
+                            "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+                        },
+                        "yargs": {
+                            "version": "15.4.1",
+                            "resolved": "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8",
+                            "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+                            "requires": {
+                                "cliui": "^6.0.0",
+                                "decamelize": "^1.2.0",
+                                "find-up": "^4.1.0",
+                                "get-caller-file": "^2.0.1",
+                                "require-directory": "^2.1.1",
+                                "require-main-filename": "^2.0.0",
+                                "set-blocking": "^2.0.0",
+                                "string-width": "^4.2.0",
+                                "which-module": "^2.0.0",
+                                "y18n": "^4.0.0",
+                                "yargs-parser": "^18.1.2"
+                            }
+                        },
+                        "yargs-parser": {
+                            "version": "18.1.3",
+                            "resolved": "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0",
+                            "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+                            "requires": {
+                                "camelcase": "^5.0.0",
+                                "decamelize": "^1.2.0"
+                            }
+                        },
+                        "zip-stream": {
+                            "version": "3.0.1",
+                            "resolved": "https://registry.yarnpkg.com/zip-stream/-/zip-stream-3.0.1.tgz#cb8db9d324a76c09f9b76b31a12a48638b0b9708",
+                            "integrity": "sha512-r+JdDipt93ttDjsOVPU5zaq5bAyY+3H19bDrThkvuVxC0xMQzU1PJcS6D+KrP3u96gH9XLomcHPb+2skoDjulQ==",
+                            "requires": {
+                                "archiver-utils": "^2.1.0",
+                                "compress-commons": "^3.0.0",
+                                "readable-stream": "^3.6.0"
+                            },
+                            "dependencies": {
+                                "readable-stream": {
+                                    "version": "3.6.0",
+                                    "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198",
+                                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                                    "requires": {
+                                        "inherits": "^2.0.3",
+                                        "string_decoder": "^1.1.1",
+                                        "util-deprecate": "^1.0.1"
+                                    }
+                                },
+                                "safe-buffer": {
+                                    "version": "5.2.1",
+                                    "resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6",
+                                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+                                },
+                                "string_decoder": {
+                                    "version": "1.3.0",
+                                    "resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e",
+                                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+                                    "requires": {
+                                        "safe-buffer": "~5.2.0"
+                                    }
+                                }
+                            }
+                        }
                     }
                 },
                 "charenc": {
@@ -1839,7 +2572,8 @@
                         "esprima": "^4.0.1",
                         "estraverse": "^4.2.0",
                         "esutils": "^2.0.2",
-                        "optionator": "^0.8.1"
+                        "optionator": "^0.8.1",
+                        "source-map": "~0.6.1"
                     },
                     "dependencies": {
                         "esprima": {
@@ -2139,6 +2873,7 @@
                     "resolved": "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.0.1.tgz#98966cba214378c8c84b82e085907b40bf614179",
                     "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
                     "requires": {
+                        "graceful-fs": "^4.1.6",
                         "universalify": "^1.0.0"
                     }
                 },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "serverless-aws-cdk",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "description": "Provider plugin for the Serverless Framework v1.x which adds support for AWS through the CDK",
     "main": "index.js",
     "directories": {


### PR DESCRIPTION
Should fix the issue mentioned in #6 - it worked fine for me because the compiled `environment.js` and `environment.d.ts` were still hanging around in my workspace, but I moved `getEnvironment()` to be a method on the `AwsCdkProvider` class.